### PR TITLE
CSS: alignment to the event information

### DIFF
--- a/_sass/events.sass
+++ b/_sass/events.sass
@@ -94,9 +94,10 @@
 
   .timeline
     margin: 0
-    padding: 0
+    padding: 20px 20px 20px 50px
     width: 100%
     display: block
+
 
     .row
       @extend .cf

--- a/_sass/tito-overrides.sass
+++ b/_sass/tito-overrides.sass
@@ -1,0 +1,9 @@
+// These changes override the Tito Widget SASS files
+.tito-ticket-list
+
+  p
+    padding: 5px 30px
+
+.tito-ticket-status
+  padding: 20px 5px
+  display: inline-block

--- a/styles.sass
+++ b/styles.sass
@@ -15,3 +15,4 @@
 @import "mentors"
 @import "tito"
 @import "mailinglist"
+@import "tito-overrides"


### PR DESCRIPTION
- adds padding to agenda timeline bullets
- adds padding to the registration notification
- creates a SASS file to override the rules found in the tito.sass

Not sure if the override file was needed. If not, let me know and I'll amend my commit and add my changes to the actual tito.sass file
