### PR TITLE
Fixed issue #23, for adding display names

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -24,18 +24,26 @@ exclude:
 
 mentors:
   - name: pcuci
+    display: 'Paul Cuciureanu'
     twitter: pcuci
   - name: cassie
+    display: 'Cassie L. Rhéaume'
     twitter: cassierheaume
   - name: david
+    display: 'David Rowley'
     twitter: davidrowley514
   - name: valeri
+    display: 'Valeri Vicneanschi'
     twitter: vicneanschi
   - name: andre-john
+    display: 'André John Mas'
     twitter: ajmas
   - name: harris
+    display: 'Harris Robin Kalash'
     twitter: LulzHRK
   - name: shawn
+    display: 'Shawn Thmpson'
     twitter: plansmash
   - name: nicolas
+    display: 'Nicolas Géré'
     twitter: nicolasgere

--- a/_layouts/index.html
+++ b/_layouts/index.html
@@ -28,6 +28,7 @@
         {% for mentor in site.mentors %}
         <pattern id="mentor-{{forloop.index}}" width="300" height="300" patternUnits="userSpaceOnUse">
           <image xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="i/mentors/{{mentor.name}}.jpg" width="250" height="300" preserveAspectRatio="xMidYMid slice">
+             <title>{{mentor.display}}</title>
           </image>
         </pattern>
         {% endfor %}
@@ -157,7 +158,9 @@ $ learnyounode</pre>
                 {% cycle '<div class="row">', '', '', '', '' %}
                   <a href="https://twitter.com/{{mentor.twitter}}" target="_blank" class="image-wrapper">
                     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 250 300" version="1.1" xmlns:xlink="http://www.w3.org/1999/xlink">
-                      <polygon class="hex" points="250,75 250,225 125,300 0,225 0,75 125,0" fill="url('#mentor-{{forloop.index}}')"></polygon>
+                      <polygon class="hex" points="250,75 250,225 125,300 0,225 0,75 125,0" fill="url('#mentor-{{forloop.index}}')">
+                         <title>{{mentor.display}}</title
+                      </polygon>
                     </svg>
                   </a>
                 {% cycle '', '', '', '', '</div>' %}


### PR DESCRIPTION
Provides a layout change and config file change for adding mentor display names. Opted to not change the 'name' value, since this almosts as a key to the GitHub user ID.
