### PR TITLE
[WIP - Don't merge] Fix mobile jank in website

### DIFF
--- a/_sass/base.sass
+++ b/_sass/base.sass
@@ -17,7 +17,8 @@ html, body
 
   @media (screen and max-width: 800px)
       margin-bottom: 100px
-      
+      overflow-x: initial
+
 strong
   font-weight: 600
 

--- a/_sass/mailinglist.sass
+++ b/_sass/mailinglist.sass
@@ -4,13 +4,23 @@
 
 .mailinglist
   @extend .cf
-  margin: 40px 0 0 -40px
-  padding: 40px
-  width: calc(100% + 80px)
+  padding: 40px 20px
+  width: 100vw
   background: lighten($secondary, 10%)
   color: $tertiary
   font-size: 16px
   position: relative
+  left: 50%
+  right: 50%
+  margin-left: -50vw
+  margin-right: -50vw
+
+  @media (screen and min-width: 800px)
+    margin: 40px 0 0 -40px
+    padding: 40px
+    width: calc(100% + 80px)
+    left: initial
+    right: initial
 
   h3
     margin-top: 0


### PR DESCRIPTION
**This fixes issue https://github.com/nodeschool/montreal/issues/98**

Currently testing slowly but surely on most browsers.

If someone can test Edge and IE11, that would be super cool.

### Tested on:

- [x] Chrome Latest
- [x] Firefox Latest
- [x] Safari OSX
- [x] Safari iOS (simulator)
- [x] Safari iOS (real device)
- [ ] Edge
- [ ] ie11

Since I removed `overflow-x hidden` on mobile, we need to tweak mailing list in mobile or else the page will bleed to the right, causing a scroll.

![diff](https://user-images.githubusercontent.com/1198051/35695853-b62e0ff4-0753-11e8-8236-b068f8d658f9.jpg)

Since I can't tell the difference between old and new changes, I'm gonna assume that the modifications that were done to compensate for the overflow-x to be a-ok.